### PR TITLE
🐛 Fix: Error about calendar, todo-list

### DIFF
--- a/src/atom/TodoListAtom.tsx
+++ b/src/atom/TodoListAtom.tsx
@@ -1,4 +1,4 @@
-import { atom } from 'recoil';
+import { atom, selector } from 'recoil';
 import { recoilPersist } from 'recoil-persist';
 
 const { persistAtom } = recoilPersist();
@@ -17,4 +17,16 @@ export const TodoListAtom = atom<TodoDataType[]>({
   key: 'TodoListAtom',
   default: [],
   effects_UNSTABLE: [persistAtom],
+});
+
+export const sortedTodoListSelector = selector({
+  key: 'sortedTodoListSelector',
+  get: ({ get }) => {
+    const todoList = get(TodoListAtom);
+    return todoList.slice().sort((a, b) => {
+      if (a.completed === 'N' && b.completed !== 'N') return -1;
+      if (a.completed !== 'N' && b.completed === 'N') return 1;
+      return 0;
+    });
+  },
 });

--- a/src/components/Calendar/ReactCalendar.style.tsx
+++ b/src/components/Calendar/ReactCalendar.style.tsx
@@ -34,7 +34,9 @@ export const StyleCalendar = styled(Calendar)`
       font-weight: 500;
     }
   }
-
+  .react-calendar__navigation button {
+    font-size: 20px;
+  }
   .react-calendar__navigation button:disabled {
     background-color: var(--color-white);
     border-radius: 20px 20px 0 0;
@@ -71,24 +73,28 @@ export const StyleCalendar = styled(Calendar)`
 
   // 다른 날짜 hover, focus, 선택
   .react-calendar__tile:enabled:hover,
-  .react-calendar__tile:enabled:focus,
-  .react-calendar__tile--active {
+  .react-calendar__tile:enabled:focus {
     background: var(--color-lightSubPrimary);
     color: var(--color-subPrimary);
   }
 
+  .react-calendar__tile--active {
+    background: #e5f2fe;
+    color: #9bcdfb;
+  }
   // 오늘 날짜 hover, focus, 선택
   .react-calendar__tile--now:enabled:hover,
-  .react-calendar__tile--now:enabled:focus {
+  .react-calendar__tile--now:enabled:focus,
+  .react-calendar__tile--now {
     background: var(--color-lightPrimary);
     color: var(--color-primary);
   }
 
   // 오늘 날짜
-  .react-calendar__tile--now {
-    background: var(--color-primary);
-    color: var(--color-white);
-  }
+  // .react-calendar__tile--now {
+  //   background: var(--color-primary);
+  //   color: var(--color-white);
+  // }
 
   .react-calendar__navigation__label {
     pointer-events: none;

--- a/src/components/Common/AddModalInput/AddModalInput.tsx
+++ b/src/components/Common/AddModalInput/AddModalInput.tsx
@@ -3,8 +3,9 @@ import { useRecoilValue } from 'recoil';
 import { SelectTabTypeAtom } from '../../../atom/SelectTabTypeAtom';
 import BookmarkAdd from './BookmarkAdd';
 import TodoAdd from './TodoAdd';
+import { ModalTypeProps } from '../Modal/Modal';
 
-export default function AddModalInput() {
+export default function AddModalInput({ date }: Pick<ModalTypeProps, 'date'>) {
   const selectTabTypeAtom = useRecoilValue(SelectTabTypeAtom);
 
   // React.ReactElement | null 타입은 완성된 jsx 요소와 null 만 허용합니다.
@@ -12,7 +13,7 @@ export default function AddModalInput() {
   let component: React.ReactElement | null = null;
 
   if (selectTabTypeAtom === 'today') {
-    component = <TodoAdd />;
+    component = <TodoAdd date={date} />;
   } else if (selectTabTypeAtom === 'bookmark') {
     component = <BookmarkAdd />;
   }

--- a/src/components/Common/AddModalInput/TodoAdd.tsx
+++ b/src/components/Common/AddModalInput/TodoAdd.tsx
@@ -5,17 +5,19 @@ import { tokenInstance } from '../../../api/Axios';
 import { AddInputWrapper, AddInput, ModalAddButton } from './AddModalInput.styled';
 import { UserAtom } from '../../../atom/UserAtom';
 import { TodoListAtom } from '../../../atom/TodoListAtom';
+import { ModalTypeProps } from '../Modal/Modal';
 
 type InputChangeEvent = React.ChangeEvent<HTMLInputElement>;
 type InputKeyboardEvent = React.KeyboardEvent<HTMLInputElement>;
 
-export default function TodoAdd() {
+export default function TodoAdd({ date }: Pick<ModalTypeProps, 'date'>) {
   const userAtom = useRecoilValue(UserAtom);
   const setTodoListAtom = useSetRecoilState(TodoListAtom);
-  const [inputValue, setInputValue] = useState('');
   const navigate = useNavigate();
+  const [inputValue, setInputValue] = useState('');
   const [isAdding, setIsAdding] = useState(false);
 
+  console.log('!@#!#@!#!#', date);
   const handleOnchange = (e: InputChangeEvent) => {
     setInputValue(e.target.value);
   };
@@ -30,28 +32,29 @@ export default function TodoAdd() {
         setInputValue('');
         return;
       }
-      let today = new Date();
-      let year = today.getFullYear(); // 년도
-      let month = (today.getMonth() + 1).toString(); // 월
-      if (month.length === 1) {
-        month = `0${month}`;
-      }
-      let date = today.getDate(); // 날짜
-      const todayDate = `${year}-${month}-${date}`;
-      console.log(todayDate);
+      // const today = new Date();
+      // const year = today.getFullYear(); // 년도
+      // let month = (today.getMonth() + 1).toString(); // 월
+      // if (month.length === 1) {
+      //   month = `0${month}`;
+      // }
+      // const date = today.getDate(); // 날짜
+      // const todayDate = `${year}-${month}-${date}`;
+      // console.log(todayDate);
 
       // 일정 생성 api
       const response1 = await tokenInstance.post('calendar/createCalendar', {
         userId: userAtom.userId,
-        targetDate: todayDate,
+        targetDate: date,
         calendarContent: inputValue,
       });
       console.log(response1);
       const data1 = response1.data;
 
       // 할 일 목록 api
-      const response2 = await tokenInstance.post('calendar/getToday', {
+      const response2 = await tokenInstance.post('calendar/getSpecificMonth', {
         userId: userAtom.userId,
+        targetDate: date,
       });
       const data2 = response2.data;
       console.log(response2);

--- a/src/components/Common/Header/TodoHeader.styled.tsx
+++ b/src/components/Common/Header/TodoHeader.styled.tsx
@@ -4,15 +4,15 @@ export const TodoHeaderWrapper = styled.div`
   width: 100%;
   display: flex;
   justify-content: space-between;
-  padding: 3.2rem 0;
+  padding: 2.8rem 0;
   /* margin-top: -2rem; */
   background-color: var(--bg-color-gray);
   border-radius: 2rem 2rem 0 0;
 `;
 
 export const TaskTitle = styled.span`
-  font-size: var(--large-font-size);
-  margin-left: 2.6rem;
+  font-size: var(--regular-font-size);
+  margin-left: 2.2rem;
 `;
 
 export const CompletedTasks = styled.span`
@@ -25,11 +25,11 @@ export const AddButton = styled.button`
   font: inherit;
   display: flex;
   align-items: center;
-  font-size: var(--small-font-size);
+  font-size: var(--xsmall-font-size);
   color: var(--text-color-main);
   border: none;
   background: none;
-  margin-right: 2.6rem;
+  margin-right: 2.2rem;
 `;
 
 export const AddIcon = styled.img`

--- a/src/components/Common/Header/TodoHeader.tsx
+++ b/src/components/Common/Header/TodoHeader.tsx
@@ -40,8 +40,7 @@ export default function TodoHeader({ date, comletedTasks, totalTasks }: HeaderPr
           onClick={() => setTodoModalOpenAtom((prev) => !prev)}
           title="할일 추가 모달 오픈"
         >
-          <AddIcon src={iconAdd} />
-          할일 추가
+          <AddIcon src={iconAdd} />할 일 추가
         </AddButton>
       )}
     </TodoHeaderWrapper>

--- a/src/components/Common/Modal/Modal.tsx
+++ b/src/components/Common/Modal/Modal.tsx
@@ -1,16 +1,19 @@
 import React, { useEffect, useState } from 'react';
 import { useRecoilValue, useResetRecoilState, useRecoilState } from 'recoil';
+import moment from 'moment';
 import { ReviseModalOpenAtom } from '../../../atom/ReviseModalOpenAtom';
 import { TodoModalOpenAtom } from '../../../atom/TodoModalOpenAtom';
 import ReviseTodoModal from './ReviseTodoModal';
 import TodoListModal from './TodoListModal';
 import WithdrawModal from './WithdrawModal';
 
-interface ModalTypeProps {
+export interface ModalTypeProps {
   type: 'revise' | 'todoList' | 'withdraw';
+  date?: string;
 }
 
-export default function Modal({ type }: ModalTypeProps) {
+const today = moment(new Date()).format('YYYY-MM-DD');
+export default function Modal({ type, date }: ModalTypeProps) {
   // 모달 사용하는 page 단위로 이동
   // const [reviseOpen, setReviseOpen] = useState(false);
   // const [withdrawOpen, setWithdrawOpen] = useState(false);
@@ -37,7 +40,11 @@ export default function Modal({ type }: ModalTypeProps) {
   };
   if (type === 'revise' && reviseModalOpenAtom)
     return <ReviseTodoModal onClose={handleCloseRevise} />;
-  if (type === 'todoList' && todoModalOpenAtom) return <TodoListModal />;
+  if (type === 'todoList' && todoModalOpenAtom) return <TodoListModal date={date} />;
   if (type === 'withdraw' && withdrawOpen) return <WithdrawModal onClose={handleCloseWithdraw} />;
   return null;
 }
+
+Modal.defaultProps = {
+  date: today,
+};

--- a/src/components/Common/Modal/TodoListModal.tsx
+++ b/src/components/Common/Modal/TodoListModal.tsx
@@ -7,8 +7,9 @@ import Tab from '../Tab/Tab';
 import { TabDataTodo } from '../Tab/TabData';
 import { ModalBackground, ModalWrapper } from './ModalLayout.styled';
 import TodoModalList from './TodoListModal/TodoModalList/TodoModalList';
+import { ModalTypeProps } from './Modal';
 
-export default function TodoListModal() {
+export default function TodoListModal({ date }: Pick<ModalTypeProps, 'date'>) {
   const setTodoModalOpenAtom = useSetRecoilState(TodoModalOpenAtom);
   const resetTabSelectTabType = useResetRecoilState(SelectTabTypeAtom);
   const selectTabType = useRecoilValue(SelectTabTypeAtom);
@@ -27,7 +28,7 @@ export default function TodoListModal() {
       <ModalWrapper onClick={(e) => e.stopPropagation()}>
         <Tab tabData={TabDataTodo} />
         <TodoModalList />
-        <AddModalInput />
+        <AddModalInput date={date} />
       </ModalWrapper>
     </ModalBackground>
   );

--- a/src/components/Common/TodoBox/TodoBox.tsx
+++ b/src/components/Common/TodoBox/TodoBox.tsx
@@ -1,4 +1,4 @@
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import moment from 'moment';
@@ -21,7 +21,7 @@ export default function TodoBox({ date }: TodoBoxProps) {
   const today = moment(new Date()).format('YYYY-MM-DD');
   const userAtom = useRecoilValue(UserAtom);
   const [todoListAtom, setTodoListAtom] = useRecoilState(TodoListAtom);
-  const [bookmarkListAtom, setBookmarkListAtom] = useRecoilState(BookmarkListAtom);
+  const setBookmarkListAtom = useSetRecoilState(BookmarkListAtom);
   const [todayTasksAtom, setTodayTasksAtom] = useRecoilState(TodayTasksAtom);
   const navigate = useNavigate();
 
@@ -38,10 +38,7 @@ export default function TodoBox({ date }: TodoBoxProps) {
   useEffect(() => {
     const fetchTodoData = async () => {
       try {
-        const url =
-          date === 'today' || date === moment(new Date()).format('YYYY-MM-DD')
-            ? 'calendar/getToday'
-            : '/calendar/getSpecificMonth';
+        const url = date === today ? 'calendar/getToday' : '/calendar/getSpecificMonth';
         const response = await tokenInstance.post(
           url,
           date === today
@@ -50,14 +47,13 @@ export default function TodoBox({ date }: TodoBoxProps) {
               }
             : { userId: userAtom.userId, targetDate: date },
         );
-        console.log('res', response);
         setTodoListAtom(response.data);
       } catch (error) {
         navigate('/error');
       }
     };
     fetchTodoData();
-    console.log(todoListAtom);
+    // console.log(todoListAtom);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [date]);
 
@@ -68,15 +64,14 @@ export default function TodoBox({ date }: TodoBoxProps) {
         const response = await tokenInstance.post('calendar/getBookmarkList', {
           userId: userAtom.userId,
         });
-        console.log(response);
         setBookmarkListAtom(response.data);
       } catch (error) {
+        // eslint-disable-next-line no-alert
         alert('즐겨찾기 데이터를 불러오는 데 실패했습니다.');
         navigate('/error');
       }
     };
     fetchBookmarkData();
-    console.log(bookmarkListAtom);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -84,7 +79,6 @@ export default function TodoBox({ date }: TodoBoxProps) {
   useEffect(() => {
     const totalTasks = todoListAtom.length;
     const completedTasks = getTodayCompletedTasks(todoListAtom);
-    console.log('TodoBox completedTasks: ', completedTasks);
     setTodayTasksAtom({ totalTasks, completedTasks });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [todoListAtom]);
@@ -97,7 +91,7 @@ export default function TodoBox({ date }: TodoBoxProps) {
         totalTasks={todayTasksAtom.totalTasks}
       />
       <TodoList date={date} />
-      <Modal type="todoList" />
+      <Modal type="todoList" date={date} />
     </TodoBoxWrapper>
   );
 }

--- a/src/components/Common/TodoBox/TodoList/TodoList.tsx
+++ b/src/components/Common/TodoBox/TodoList/TodoList.tsx
@@ -2,7 +2,7 @@
 import React, { useState } from 'react';
 import moment from 'moment';
 import { useRecoilValue } from 'recoil';
-import { TodoListAtom } from '../../../../atom/TodoListAtom';
+import { TodoListAtom, sortedTodoListSelector } from '../../../../atom/TodoListAtom';
 import { TodoListUl, TodoListWrapper, MoreBtn } from './TodoList.styled';
 import TodoListItem from './TodoListItem/TodoListItem';
 import Icon from '../../../../assets/icons/icon-more-meatball.svg';
@@ -13,16 +13,18 @@ interface ListProps {
 
 export default function TodoList({ date }: ListProps) {
   const todoListAtom = useRecoilValue(TodoListAtom);
+  // completed 여부로 정렬된 todoListAtom값
+  const sortedTodoList = useRecoilValue(sortedTodoListSelector);
   const today = moment(new Date()).format('YYYY-MM-DD');
-
   const [showAll, setShowAll] = useState(false);
-  console.log(todoListAtom);
 
-  const visibleItems = showAll ? todoListAtom : todoListAtom.slice(0, 8);
+  // console.log('sorted', sortedTodoList);
+  const visibleItems = showAll ? sortedTodoList : sortedTodoList.slice(0, 8);
 
   const toggleShowAll = () => {
     setShowAll(!showAll);
   };
+
   return (
     <TodoListWrapper>
       <TodoListUl>

--- a/src/components/Common/TodoBox/TodoList/TodoListItem/TodoListItem.styled.tsx
+++ b/src/components/Common/TodoBox/TodoList/TodoListItem/TodoListItem.styled.tsx
@@ -2,7 +2,7 @@ import { styled } from 'styled-components';
 
 export const TodoItemWrapper = styled.li`
   box-sizing: border-box;
-  font-size: var(--small-font-size);
+  font-size: var(--xsmall-font-size);
   display: flex;
   justify-content: center;
   gap: 6px;

--- a/src/components/Common/TodoBox/TodoList/TodoListItem/TodoListItem.tsx
+++ b/src/components/Common/TodoBox/TodoList/TodoListItem/TodoListItem.tsx
@@ -9,6 +9,7 @@ import { TodayTasksAtom } from '../../../../../atom/TodayTasksAtom';
 import { tokenInstance } from '../../../../../api/Axios';
 import ItemMenuButton from './ItemMenuButton';
 import Modal from '../../../Modal/Modal';
+import { TodoNumAtom } from '../../../../../atom/TodoNumAtom';
 
 interface TodoListItemProps {
   todo: TodoDataType;
@@ -18,6 +19,8 @@ interface TodoListItemProps {
 export default function TodoListItem({ todo, date }: TodoListItemProps) {
   const [completed, setCompleted] = useState(false);
   const [todayTasksAtom, setTodayTasksAtom] = useRecoilState(TodayTasksAtom);
+  const [todoNum, setTodoNum] = useRecoilState(TodoNumAtom);
+
   const setTodoListAtom = useSetRecoilState(TodoListAtom);
   const navigate = useNavigate();
   const today = moment(new Date()).format('YYYY-MM-DD');
@@ -59,13 +62,16 @@ export default function TodoListItem({ todo, date }: TodoListItemProps) {
             },
       );
 
-      console.log(getTodayResponse);
       const totalTasks = getTodayResponse.data.length;
       const completedTasks = getTodayCompletedTasks(getTodayResponse.data);
 
       if (completeCalendarResponse.data === '변경 되었습니다.') {
         setTodoListAtom(getTodayResponse.data);
         setTodayTasksAtom({ totalTasks, completedTasks });
+        setTodoNum((prevTodoNum) => ({
+          ...prevTodoNum,
+          [date]: { totalTodo: totalTasks, completedTodo: completedTasks },
+        }));
         setCompleted((prev) => !prev);
       }
     } catch (error) {

--- a/src/pages/CalendarPage/CalendarPage.tsx
+++ b/src/pages/CalendarPage/CalendarPage.tsx
@@ -1,32 +1,27 @@
 import React, { useEffect, useState } from 'react';
 import moment from 'moment';
-import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useNavigate } from 'react-router-dom';
 import ReactCalendar from '../../components/Calendar/ReactCalendar';
 import { UserAtom } from '../../atom/UserAtom';
 import { tokenInstance } from '../../api/Axios';
 import { TodoNumAtom } from '../../atom/TodoNumAtom';
-// import { useHook } from '../../components/customHook';
 
 export default function CalendarPage() {
-  interface TodoDataProps {
-    totalTodo: number;
-    completedTodo: number;
-  }
-
   interface DataGroupProps {
     [date: string]: any[];
   }
 
   const userAtom = useRecoilValue(UserAtom);
   const [date, setDate] = useState(new Date());
-  const [TodoNum, setTodoNum] = useRecoilState(TodoNumAtom);
+  const setTodoNum = useSetRecoilState(TodoNumAtom);
+  const navigate = useNavigate();
 
   const convertedDate = {
     date: '',
     month: '',
   };
   const [dataGroup, setDataGroup] = useState<DataGroupProps>({});
-  const [todoObj, setTodoObj] = useState<Record<string, TodoDataProps>>({});
 
   // date에서 월 단위 추출
   const onConvertDate = (d: Date) => {
@@ -60,14 +55,15 @@ export default function CalendarPage() {
         });
         const groupedData = groupDataByDate(response.data);
         setDataGroup(groupedData);
-        console.log('123123123', groupedData);
+        // console.log('123123123', groupedData);
       } catch (error) {
-        console.error('데이터를 불러오는 중 오류 발생:', error);
+        navigate('/error');
       }
     };
     fetchData();
-  }, [userAtom.userId, convertedDate.month]);
+  }, [userAtom.userId, convertedDate.month, navigate]);
 
+  // console.log(TodoNum);
   // dataGroup -> 일자 별 일정, 완료 갯수 계산
   useEffect(() => {
     const calculateTodoNum = () => {
@@ -80,17 +76,11 @@ export default function CalendarPage() {
           totalTodo,
           completedTodo,
         };
-        console.log('CalendarPage completedTodo:', completedTodo);
       });
-      setTodoObj(todoNum);
       setTodoNum(todoNum);
-      console.log('Todonum:', TodoNum);
-      console.log('Todo Num by date:', todoNum);
     };
     calculateTodoNum();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dataGroup, setTodoNum, userAtom.userId]);
-  return (
-    <div>{dataGroup && <ReactCalendar value={date} setValue={setDate} todoObj={todoObj} />}</div>
-  );
+  return <div>{dataGroup && <ReactCalendar value={date} setValue={setDate} />}</div>;
 }

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
+import moment from 'moment';
 import { useNavigate } from 'react-router-dom';
 import { UserAtom } from '../../atom/UserAtom';
 import { fortuneDataAtom } from '../../atom/FortuneStateAtom';
@@ -11,6 +12,7 @@ export default function HomePage() {
   const userAtom = useRecoilValue(UserAtom);
   const setFortuneData = useSetRecoilState(fortuneDataAtom);
   const navigate = useNavigate();
+  const today = moment(new Date()).format('YYYY-MM-DD');
 
   // 오늘의 운세 api 호출
   useEffect(() => {
@@ -52,10 +54,11 @@ export default function HomePage() {
         display: 'flex',
         flexDirection: 'column',
         overflow: 'auto',
+        backgroundColor: '#7E7DFD',
       }}
     >
       <MainCard />
-      <TodoBox date="today" />
+      <TodoBox date={today} />
       <NavBar />
     </div>
   );

--- a/src/pages/ProfilePage/ProfilePage.tsx
+++ b/src/pages/ProfilePage/ProfilePage.tsx
@@ -2,14 +2,7 @@ import React from 'react';
 import { useRecoilValue } from 'recoil';
 import { useNavigate } from 'react-router-dom';
 import { UserAtom } from '../../atom/UserAtom';
-import {
-  ProfileName,
-  ProfileTitle,
-  ProfileWrapper,
-  Img,
-  ProfileMain,
-  Gear,
-} from './ProfilePage.styled';
+import { ProfileName, ProfileTitle, ProfileWrapper, ProfileMain, Gear } from './ProfilePage.styled';
 import { ChartComponent } from '../../components/Chart/ChartComponent';
 
 export default function ProfilePage() {

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -43,6 +43,7 @@ const GlobalStyle = createGlobalStyle`
 		--large-font-size: 2rem;
 		--regular-font-size: 1.8rem;
 		--small-font-size: 1.6rem;
+		--xsmall-font-size: 1.4rem;
 		--tiny-font-size: 1rem;
 
 		/*========== Color ==========*/
@@ -92,15 +93,6 @@ const GlobalStyle = createGlobalStyle`
     --color-lightSubPrimary: #FEE4F9;
     --color-todoCircle: #F4F4F4;
 	}
-
-		/* Calendar */
-		--color-gray: #8B8B8B;
-    --color-lightgray: #bdbdbd;
-    --color-primary: #7E7DFD;
-    --color-lightPrimary: #E5E5FE;
-    --color-subPrimary: #FD7CE3;
-    --color-lightSubPrimary: #FEE4F9;
-    --color-todoCircle: #F4F4F4;
 	/*=============== Responsive ===============*/
 	body {
 		margin: 0 auto;


### PR DESCRIPTION
### 완료
- TodoBox 내 일정 완료 및 취소 → Calendar 내 남은 일정 개수 바로 반영 
- Home, Calendar에서 오늘, 다른 날짜 및 일정 보여주기 (TodoBox 에러 고치기)
- Modal(Add) 날짜에 맞는 할 일 추가 로직으로 수정 
- 이전 혹은 다음 달로 이동하는 경우 해당 달의 todoList 불러오기
- 완료, 미완료 체크에 따라 할일 목록 정렬해서 보여주기
- css 조금 수정

### 미완료
- 클릭한 날짜 유지하기
- 할 일 추가하는 경우 캘린더에 남은 할 일 개수 바로 증가시켜 반영하기 