### PR TITLE
🎨 Style : profile 페이지 스타일 수정

### DIFF
--- a/src/pages/ProfilePage/ProfilePage.styled.tsx
+++ b/src/pages/ProfilePage/ProfilePage.styled.tsx
@@ -12,14 +12,15 @@ export const MenuSection = styled.section`
   gap: 8rem;
   color: var(--color-white);
 
-  p {
+  .menu_title {
     font-size: 3.6rem;
+    margin-bottom: 4rem;
   }
 
-  li {
+  .menu_li {
     font-size: 2.4rem;
   }
-  li:not(:last-child) {
+  .menu_li:not(:last-child) {
     margin-bottom: 2.6rem;
   }
   .menu-txt {
@@ -112,7 +113,9 @@ export const ProfileMain = styled.p`
   @media screen and (min-width: 960px) {
     font-size: 2rem;
     padding: 3.5rem 0;
-    text-align: center;
+    text-align: left;
+    white-space: nowrap;
+    width: 100%;
   }
 `;
 

--- a/src/pages/ProfilePage/ProfilePage.tsx
+++ b/src/pages/ProfilePage/ProfilePage.tsx
@@ -38,29 +38,31 @@ export default function ProfilePage({ isDesktop }: { isDesktop: boolean }) {
     <main>
       <DesktopProfileWrapper>
         <MenuSection>
-          <p>마이페이지</p>
-          <ul>
-            <li>
-              <Link to="/editUser" className="menu-txt">
-                내 정보 수정
-              </Link>
-            </li>
-            <li>
-              <Link to="/editPassword" className="menu-txt">
-                비밀번호 변경
-              </Link>
-            </li>
-            <li>
-              <button onClick={handleLogout} type="button">
-                로그아웃
-              </button>
-            </li>
-            <li>
-              <button onClick={handleWithdraw} type="button">
-                회원 탈퇴
-              </button>
-            </li>
-          </ul>
+          <div className="MenuSection-menu_wrapper">
+            <p className="menu_title">마이페이지</p>
+            <ul className="menu_ul">
+              <li className="menu_li">
+                <Link to="/editUser" className="menu-txt">
+                  내 정보 수정
+                </Link>
+              </li>
+              <li className="menu_li">
+                <Link to="/editPassword" className="menu-txt">
+                  비밀번호 변경
+                </Link>
+              </li>
+              <li className="menu_li">
+                <button onClick={handleLogout} type="button">
+                  로그아웃
+                </button>
+              </li>
+              <li className="menu_li">
+                <button onClick={handleWithdraw} type="button">
+                  회원 탈퇴
+                </button>
+              </li>
+            </ul>
+          </div>
           {modal && (
             <ModalBackground>
               <WithdrawModal onClose={() => setModal(false)} />


### PR DESCRIPTION
- menu_title, menu_ul을 MenuSection-menu_wrapper로 감쌈
- menu_title과 menu_ul의 간격은 margin-bottom 으로 처리
- ChartTxtWrapper에 ProfileMain에 white-space: nowrap 으로 줄바꿈 제거
- text-align: left로 텍스트 시작점 동일하게 유지