### PR TITLE
♻️ Refactor: 모바일화면에서 캘린더 페이지 스타일 조정

### DIFF
--- a/src/components/MainCard/MainCard.styled.tsx
+++ b/src/components/MainCard/MainCard.styled.tsx
@@ -61,6 +61,11 @@ export const UserName = styled.p`
 export const TodayFortune = styled.p`
   line-height: 2.8rem;
   font-size: var(--h3-font-size);
+  button {
+    color: var(--color-white);
+    cursor: pointer;
+    font-family: var(--font-family-bold);
+  }
 `;
 
 export const TextBox = styled.div`

--- a/src/components/MainCard/MainCard.tsx
+++ b/src/components/MainCard/MainCard.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import { UserAtom } from '../../atom/UserAtom';
 import { fortuneDataAtom } from '../../atom/FortuneStateAtom';
@@ -26,6 +27,11 @@ export default function MainCard({ isDesktop }: { isDesktop?: boolean }) {
 
   const userAtom = useRecoilValue(UserAtom);
   const { fortuneTitle } = useRecoilValue(fortuneDataAtom);
+  const navigate = useNavigate();
+
+  const handleFortuneClick = () => {
+    navigate('/fortune');
+  };
 
   return (
     <MainCardWrapper>
@@ -38,7 +44,9 @@ export default function MainCard({ isDesktop }: { isDesktop?: boolean }) {
             </UserName>
             <TodayFortune>오늘 하루는</TodayFortune>
             <TodayFortune>
-              <span>{fortuneTitle}</span>
+              <button type="button" onClick={handleFortuneClick}>
+                {fortuneTitle}
+              </button>
               이네요!
             </TodayFortune>
           </TextBox>


### PR DESCRIPTION
## 최지완
* 모바일 화면의 캘린더 페이지에서 캘린더의 높이로 인해 오늘의 할일 리스트가 보이지 않는 문제가 있어 캘린더의 높이를 조정
* homepage의 사자성어 섹션에 fortunePage로 이동하는 링크 추가